### PR TITLE
Fixes Python object caching memory leaks

### DIFF
--- a/bblfsh/pyuast.cc
+++ b/bblfsh/pyuast.cc
@@ -824,9 +824,12 @@ public:
         ctx = impl->NewContext();
     }
     ~Context(){
+        // Deleting ctx also frees impl
         delete(ctx);
-        delete(impl);
+        ctx = nullptr;
+        impl = nullptr;
         delete(iface);
+        iface = nullptr;
     }
 
     // RootNode returns a root UAST node, if set.

--- a/bblfsh/pyuast.cc
+++ b/bblfsh/pyuast.cc
@@ -601,10 +601,10 @@ class Context;
 class Interface : public uast::NodeCreator<Node*> {
 private:
     // Thread safety is ensured here by Python's GIL (Global Interpreter Lock), since only
-    // a method could enter in a C++ routine at a time. Note that the STL container used
-    // to cache the objects does not ensure two concurrent writes thread safety, but GIL in
-    // this case indirectly provides us that feature. Also ensures thread safety for the
-    // lookupOrCreate and createIfNotExists methods
+    // a method could enter in a C++ routine at a time.
+    // The STL container used to cache the objects does not support concurrent writes, but
+    // Python's GIL (Global Interpreter Lock) ensures lookupOrCreate and createIfNotExists
+    // will not execute concurrently, avoiding concurrent writers to the cache.
     std::unordered_map<PyObject*, Node*> obj2node;
 
     static PyObject* newBool(bool v) {
@@ -676,14 +676,14 @@ public:
 
     Node* NewObject(size_t size) {
         // Object is going to be created and cached, since when
-        // we call PyDict_New we are retruned a new reference
+        // we call PyDict_New we returned a new reference
         // and therefore we are not going to use a cached one.
         PyObject* m = PyDict_New();
         return createIfNotExists(NODE_OBJECT, m);
     }
     Node* NewArray(size_t size) {
         // Array is going to be created and cached, since when
-        // we call PyList_New we are retruned a new reference
+        // we call PyList_New we returned a new reference
         // and therefore we are not going to use a cached one.
         PyObject* arr = PyList_New(size);
         return createIfNotExists(NODE_ARRAY, arr);

--- a/bblfsh/pyuast.cc
+++ b/bblfsh/pyuast.cc
@@ -1,7 +1,7 @@
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
-#include <map>
+#include <unordered_map>
 
 #include <Python.h>
 #include <structmember.h>
@@ -600,7 +600,7 @@ class Context;
 
 class Interface : public uast::NodeCreator<Node*> {
 private:
-    std::map<PyObject*, Node*> obj2node;
+    std::unordered_map<PyObject*, Node*> obj2node;
 
     static PyObject* newBool(bool v) {
         if (v) Py_RETURN_TRUE;

--- a/bblfsh/pyuast.cc
+++ b/bblfsh/pyuast.cc
@@ -345,6 +345,7 @@ static PyObject *PythonContextExt_filter(PythonContextExt *self, PyObject *args,
         PyErr_SetString(PyExc_RuntimeError, e.what());
     }
 
+    Py_INCREF((PyObject *)self);
     return it;
 }
 
@@ -933,6 +934,7 @@ static PyObject *PythonContext_filter(PythonContext *self, PyObject *args, PyObj
         PyErr_SetString(PyExc_RuntimeError, e.what());
     }
 
+    Py_INCREF((PyObject *)self);
     return it;
 }
 

--- a/bblfsh/pyuast.cc
+++ b/bblfsh/pyuast.cc
@@ -600,6 +600,11 @@ class Context;
 
 class Interface : public uast::NodeCreator<Node*> {
 private:
+    // Thread safety is ensured here by Python's GIL (Global Interpreter Lock), since only
+    // a method could enter in a C++ routine at a time. Note that the STL container used
+    // to cache the objects does not ensure two concurrent writes thread safety, but GIL in
+    // this case indirectly provides us that feature. Also ensures thread safety for the
+    // lookupOrCreate and createIfNotExists methods
     std::unordered_map<PyObject*, Node*> obj2node;
 
     static PyObject* newBool(bool v) {

--- a/bblfsh/pyuast.cc
+++ b/bblfsh/pyuast.cc
@@ -631,6 +631,9 @@ private:
         Node* node = obj2node[obj];
         // This object's node is already cached; release the reference.
         if (node) {
+            // It is safe to DECREF here, since an INCREF has already happened at
+            // NewString (in PyUnicode_FromString), NewInt (in PyLong_FromLongLong),
+            // NewUint, NewFloat or NewBool
             Py_DECREF(obj);
             return node;
         }
@@ -667,10 +670,16 @@ public:
     }
 
     Node* NewObject(size_t size) {
+        // Object is going to be created and cached, since when
+        // we call PyDict_New we are retruned a new reference
+        // and therefore we are not going to use a cached one.
         PyObject* m = PyDict_New();
         return createIfNotExists(NODE_OBJECT, m);
     }
     Node* NewArray(size_t size) {
+        // Array is going to be created and cached, since when
+        // we call PyList_New we are retruned a new reference
+        // and therefore we are not going to use a cached one.
         PyObject* arr = PyList_New(size);
         return createIfNotExists(NODE_ARRAY, arr);
     }

--- a/bblfsh/pyuast.cc
+++ b/bblfsh/pyuast.cc
@@ -833,13 +833,9 @@ public:
         ctx = impl->NewContext();
     }
     ~Context(){
-        // impl gets deleted when deleting ctx
-        delete(ctx);
-        delete(impl);
-        delete(iface);
-        ctx = nullptr;
-        impl = nullptr;
-        iface = nullptr;
+        delete(ctx); ctx = nullptr;
+        delete(impl); impl = nullptr;
+        delete(iface); iface = nullptr;
     }
 
     // RootNode returns a root UAST node, if set.

--- a/bblfsh/pyuast.cc
+++ b/bblfsh/pyuast.cc
@@ -508,7 +508,8 @@ public:
             str = new std::string(s);
         }
 
-        return str;
+        std::string* s = new std::string(*str);
+        return s;
     }
     int64_t AsInt() {
         long long v = PyLong_AsLongLong(obj);
@@ -826,6 +827,7 @@ public:
     ~Context(){
         // impl gets deleted when deleting ctx
         delete(ctx);
+        delete(impl);
         delete(iface);
         ctx = nullptr;
         impl = nullptr;

--- a/bblfsh/pyuast.cc
+++ b/bblfsh/pyuast.cc
@@ -620,15 +620,15 @@ private:
         return node;
     }
 
-    // create makes a new object with a specified kind, as long as it does
-    // not already exists. If it does, it just outputs the existing Node
-    // and decreases the ref count to obj
-    // Steals the reference iff the object does not already exists
+    // createIfNotExists creates and caches a node corresponding to the given object, if
+    // one does not already exist. This function takes ownership of the caller's reference
+    // to obj: If a new node is created, the reference is delegated to the cache; otherwise
+    // it is released.
     Node* createIfNotExists(NodeKind kind, PyObject* obj) {
         if (!obj || obj == Py_None) return nullptr;
 
         Node* node = obj2node[obj];
-        // If obj is already cached, we do not want another reference to it
+        // This object's node is already cached; release the reference.
         if (node) {
             Py_DECREF(obj);
             return node;


### PR DESCRIPTION
* ~~Deletes unbalanced `Py_INCREF` [here](https://github.com/bblfsh/python-client/blob/dfda83d6d29e4a385690deda450c6f077ee1e84c/bblfsh/pyuast.cc#L347), and analogously for `PythonContext_filter`. The rationale behind this is that this `Py_INCREF` has no effect because of `NodeIterator` [saving a pointer to `ctx`](https://github.com/bblfsh/python-client/blob/dfda83d6d29e4a385690deda450c6f077ee1e84c/bblfsh/node_iterator.py#L19). Another alternative would be to do a `Py_DECREF` in `PyUastIterExt_dealloc`, but `PyUastIterExt` is also used for free contexts which are not associated to a Python object, so I think this is the cleanest solution.~~ This would be addressed separately #181,
* Python shares ints and strings in memory (for ints I think it is in a certain range [0,256]). Let us suppose we try to create two Python objects which hold the integer `26` (-> we would be returned the same reference, but with count 2). Thus, when we create a new node associated to the two integers [here](https://github.com/bblfsh/python-client/blob/dfda83d6d29e4a385690deda450c6f077ee1e84c/bblfsh/pyuast.cc#L627), we are only storing a single node (we are overwriting it) , so we would only decrease `26` one time when we free `Interface`. I now store a list of the creates nodes to free them when `Interface` is released, and I cache only the last one corresponding to a certain Python object. This would work as long as we are not planing to let the user modify a node in the tree (?).

Needs https://github.com/bblfsh/libuast/pull/107. The former, #181 and this PR solve #176 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bblfsh/python-client/176)
<!-- Reviewable:end -->
