### PR TITLE
Adds children order

### DIFF
--- a/bblfsh/test.py
+++ b/bblfsh/test.py
@@ -330,6 +330,14 @@ class BblfshTests(unittest.TestCase):
         self.assertEqual(set(expanded), {'root', 'son1', 'son2', 'son1_1',
                                          'son1_2', 'son2_1', 'son2_2'})
 
+    def testAnyOrder(self) -> None:
+        root = self._itTestTree()
+        it = iterator(root, TreeOrder.CHILDREN_ORDER)
+        self.assertIsNotNone(it)
+        expanded = self._get_nodetypes(it)
+        # We only can test that the order gives us all the nodes
+        self.assertEqual(set(expanded), {'son1', 'son2'})
+
     # Iterating from the root node should give the same result as
     # iterating from the tree, for every available node
     def testNodeIteratorEqualsCtxIterator(self) -> None:

--- a/bblfsh/test.py
+++ b/bblfsh/test.py
@@ -270,16 +270,21 @@ class BblfshTests(unittest.TestCase):
 
     @staticmethod
     def _position_sort(x, y):
-        (a, b, c) = x
-        (e, f, g) = y
+        (off1, line1, col1) = x
+        (off2, line2, col2) = y
 
-        if a == 0 or e == 0 or (b == 0 and c == 0) or (f == 0 and g == 0):
-            if b != c:
-                return b - f
-            else:
-                return c - g
+        def has_offset(off, line, col):
+            off != 0 or (line == 1 and col == 1)
+
+        # Extracted from here
+        # https://github.com/bblfsh/sdk/blob/a2cab92/uast/uast.go#L124
+        if has_offset(off1, line1, col1) and has_offset(off2, line2, col2):
+            return off1 - off2
         else:
-            return a - b
+            if line1 != line2:
+                return line1 - line2
+
+            return col1 - col2
 
     def testIteratorPreOrder(self) -> None:
         root = self._itTestTree()
@@ -336,7 +341,7 @@ class BblfshTests(unittest.TestCase):
         self.assertIsNotNone(it)
         expanded = self._get_nodetypes(it)
         # We only can test that the order gives us all the nodes
-        self.assertEqual(set(expanded), {'son1', 'son2'})
+        self.assertEqual(expanded, ['son1', 'son2'])
 
     # Iterating from the root node should give the same result as
     # iterating from the tree, for every available node

--- a/bblfsh/test.py
+++ b/bblfsh/test.py
@@ -11,6 +11,7 @@ from bblfsh.client import NonUTF8ContentException
 from bblfsh.node import NodeTypedGetException
 from bblfsh.result_context import (Node, NodeIterator, ResultContext)
 from bblfsh.pyuast import uast, decode
+from functools import cmp_to_key
 
 class BblfshTests(unittest.TestCase):
     BBLFSH_SERVER_EXISTED = None
@@ -267,6 +268,19 @@ class BblfshTests(unittest.TestCase):
                                    "start" in x["@pos"].keys(), nodes) ]
         return [ (int(n["offset"]), int(n["line"]), int(n["col"])) for n in start_positions ]
 
+    @staticmethod
+    def _position_sort(x, y):
+        (a, b, c) = x
+        (e, f, g) = y
+
+        if a == 0 or e == 0 or (b == 0 and c == 0) or (f == 0 and g == 0):
+            if b != c:
+                return b - f
+            else:
+                return c - g
+        else:
+            return a - b
+
     def testIteratorPreOrder(self) -> None:
         root = self._itTestTree()
         it = iterator(root, TreeOrder.PRE_ORDER)
@@ -304,7 +318,8 @@ class BblfshTests(unittest.TestCase):
         ctx = self._parse_fixture()
         it = ctx.iterate(TreeOrder.POSITION_ORDER)
         positions = self._get_positions(it)
-        self.assertListEqual(positions, sorted(positions))
+        sorted_pos = sorted(positions, key = cmp_to_key(self._position_sort))
+        self.assertListEqual(positions, sorted_pos)
 
     def testAnyOrder(self) -> None:
         root = self._itTestTree()

--- a/bblfsh/tree_order.py
+++ b/bblfsh/tree_order.py
@@ -1,5 +1,5 @@
 from enum import IntEnum
-from bblfsh.pyuast import AnyOrder, PreOrder, PostOrder, LevelOrder, PositionOrder
+from bblfsh.pyuast import AnyOrder, PreOrder, PostOrder, LevelOrder, ChildrenOrder, PositionOrder
 
 class TreeOrder(IntEnum):
     # Gives no assurances over the iteration order of the tree
@@ -9,6 +9,7 @@ class TreeOrder(IntEnum):
     PRE_ORDER      = PreOrder
     POST_ORDER     = PostOrder
     LEVEL_ORDER    = LevelOrder
+    CHILDREN_ORDER = ChildrenOrder
     POSITION_ORDER = PositionOrder
 
     @staticmethod

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ from setuptools.command.build_ext import build_ext
 # The VERSION line is edited automatically during deployments.
 # You may change the contents of the string, but do not otherwise edit the line.
 VERSION = "3.x.x-dev"
-LIBUAST_VERSION = "v3.4.1"
+LIBUAST_VERSION = "v3.4.2"
 SDK_V1_VERSION = "v1.17.0"
 SDK_V1_MAJOR = SDK_V1_VERSION.split('.')[0]
 SDK_V2_VERSION = "v2.16.4"


### PR DESCRIPTION
It needs a new release of  [sdk](https://github.com/bblfsh/sdk) and [libuast](https://github.com/bblfsh/libuast) to work (travis would fail until we do them). It also includes d86fefe which should have been included in #180 :see_no_evil: and adds the order for positions as is in the SDK, instead of lexicographical order of `(offset, line, column)`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bblfsh/python-client/187)
<!-- Reviewable:end -->
