### PR TITLE
Adds timeout of 60 seconds to parse requests

### DIFF
--- a/bblfsh/client.py
+++ b/bblfsh/client.py
@@ -55,7 +55,7 @@ class BblfshClient:
 
     def parse(self, filename: str, language: Optional[str]=None,
               contents: Optional[str]=None, mode: Optional[ModeType]=None,
-              timeout: Optional[int]=None) -> ResultContext:
+              timeout: int=60) -> ResultContext:
         """
         Queries the Babelfish server and receives the UAST response for the specified
         file.
@@ -68,13 +68,16 @@ class BblfshClient:
         :param contents: The contents of the file. IF None, it is read from \
                          filename.
         :param mode:     UAST transformation mode.
-        :param timeout: The request timeout in seconds.
+        :param timeout: The request timeout in seconds. Zero or negative \
+                        means no timeout.
         :type filename: str
         :type language: str
         :type contents: str
         :type timeout: float
         :return: UAST object.
         """
+        if timeout is None or timeout <= 0:
+                timeout = None
 
         # TODO: handle syntax errors
         contents = self._get_contents(contents, filename)


### PR DESCRIPTION
Mirrors https://github.com/bblfsh/scala-client/pull/133. We already had a `timeout` parameter here, but with default value of `None` (no timeout). Default timeout has been set to 60 seconds as in `scala-client`

Signed-off-by: ncordon <nacho.cordon.castillo@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bblfsh/python-client/194)
<!-- Reviewable:end -->
